### PR TITLE
Ts 61 fix failing deploy of stub api

### DIFF
--- a/Stubs/.cfn_nag_blacklist
+++ b/Stubs/.cfn_nag_blacklist
@@ -1,8 +1,0 @@
----
-RulesToSuppress:
-- id: W64
-  reason: UsagePlan not required
-- id: W68
-  reason: UsagePlan not required
-- id: W69
-  reason: Accesslogging not required

--- a/Stubs/buildspec.yml
+++ b/Stubs/buildspec.yml
@@ -7,16 +7,11 @@ phases:
 
   install:
     runtime-versions:
-      python: 3.12
-      ruby: 2.6
+      python: 3.13
     commands:
       - pip3 install --upgrade cfn-lint
-      # Upgrade AWS CLI to the latest version
       - pip3 install --upgrade awscli
-      # Install aws-sam-cli
-      - pip3 install aws-sam-cli
-      # Install cfn_nag
-      - gem install cfn-nag
+      - pip3 install aws-sam-cli -U
       - pip3 install --upgrade pip -r Stubs/requirements.txt
 
   pre_build:
@@ -25,21 +20,18 @@ phases:
       - env
       - aws --version
       - cfn-lint -v
-      - cfn_nag -v
+      - sam --version
 
       # Lint
       - cfn-lint # uses .cfnlintrc
       - cd Stubs
-
-      # Run cfn-nag (looks for patterns in CFN templates that may indicate insecure infrastructure)
-      - cfn_nag_scan --output-format txt --print-suppression --blacklist-path .cfn_nag_blacklist --input-path . --template-pattern '^(?!.*buildspec\.y[a]?ml)((..*\.y[a]?ml)|(..*\.template))$'
 
   build:
     commands:
       - echo Build started on `date`
       - ls -a
       # Use AWS SAM to build and package the application by using AWS CloudFormation
-      - sam build --debug
+      - sam build
       - sam package --s3-bucket $S3_BUCKET --output-template-file packaged.yml
 
       # Lint after 'package'

--- a/Stubs/buildspec.yml
+++ b/Stubs/buildspec.yml
@@ -7,7 +7,7 @@ phases:
 
   install:
     runtime-versions:
-      python: 3.13
+      python: 3.12
     commands:
       - pip3 install --upgrade cfn-lint
       - pip3 install --upgrade awscli

--- a/Stubs/pipeline.yml
+++ b/Stubs/pipeline.yml
@@ -333,7 +333,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: S3_BUCKET

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -29,7 +29,7 @@ phases:
       - npm install
       - npm test
       - cd ../karate
-      - ./gradlew test
+      - ./gradlew test --info
 
   post_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,7 +5,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 18
+      nodejs: 22
       java: corretto21
     commands:
       - node -v
@@ -29,7 +29,7 @@ phases:
       - npm install
       - npm test
       - cd ../karate
-      - ./gradlew test --info
+      - ./gradlew test
 
   post_build:
     commands:

--- a/karate/src/test/resources/logback.xml
+++ b/karate/src/test/resources/logback.xml
@@ -1,0 +1,5 @@
+<!-- Avoid filling up logs with unwanted info when running tests -->
+<configuration>
+  <logger name="org.thymeleaf" level="WARN"/>
+  <!-- Andre logger-konfigurasjoner -->
+</configuration>


### PR DESCRIPTION
The build failed due to an EOL Ruby version, and the only thing using Ruby is cfn-nag.  
Other than that, just some minor improvements.