### PR TITLE
Ts 214 fix npm ci errors next step

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,7 +12,6 @@ phases:
       - npm -v
       - npm i -g npm
       - npm -v
-      - which npm
   pre_build:
     commands:
       - echo "pre_build steps for revision ${CODEBUILD_RESOLVED_SOURCE_VERSION}..."
@@ -26,8 +25,6 @@ phases:
 
   build:
     commands:
-      - npm -v
-      - which npm
       - cd cypress
       - npm ci
       - npm run sandboxTest || true

--- a/cypress/.npmrc
+++ b/cypress/.npmrc
@@ -1,1 +1,0 @@
-min-release-age=7d

--- a/integrasjonstester/.npmrc
+++ b/integrasjonstester/.npmrc
@@ -1,1 +1,0 @@
-min-release-age=7d


### PR DESCRIPTION
Removing .npmrc files because of a bug with NPM and versioning semantics causing npm ci to fail